### PR TITLE
chore(deps): bump quinn-proto from 0.11.14 to 0.11.17 in /packages/eql

### DIFF
--- a/packages/eql/Cargo.lock
+++ b/packages/eql/Cargo.lock
@@ -2774,15 +2774,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2910,6 +2911,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"


### PR DESCRIPTION
## Summary

Security bump of `quinn-proto` (a QUIC protocol implementation, a transitive dependency of the EQL Rust workspace) from 0.11.14 to 0.11.17. The new releases fix four remote memory-exhaustion issues: GHSA-qfwj-vfxf-92j2, GHSA-2hv7-gw8g-gpq5, GHSA-hmxj-32vh-65vr, and GHSA-4w2j-m93h-cj5j.

This is Dependabot's #930 re-opened from a maintainer branch. Workflows triggered by Dependabot read the separate Dependabot secrets store, which holds CipherStash credentials for a different keyset than the Actions store — so the EQL SQLx suite's pinned SteVec selector tests fail on every Dependabot PR for reasons unrelated to the bump. A maintainer branch runs CI with the normal Actions secrets.

## Changes

- `packages/eql/Cargo.lock`: quinn-proto 0.11.14 → 0.11.17 (lock-only, same commit as #930, cherry-picked)

## Verification

- Cherry-pick applied cleanly onto current main; no manifest changes, lockfile only.
- CI on this PR is the verification — the Dependabot run's failures were traced to the secret-store mismatch (the `jsonb_entry_integer_selector_matches_fixture` drift guard fired), not the bump.

## Related

- Replaces #930 (closed in favour of this PR).

https://claude.ai/code/session_01PS9J6pu3FmmQvJHxwTVJUc