### PR TITLE
chore(deps): bump the actions-minor-patch group with 3 updates

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,11 +31,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.5
+        uses: github/codeql-action/init@v4.37.7
         with:
           languages: ${{ matrix.language }}
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/init@v4.37.5
+        uses: github/codeql-action/init@v4.37.7
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   osv-scan:
     name: OSV Vulnerability Scan
-    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.5.1
     with:
       fail-on-vuln: false
       scan-args: |-

--- a/.github/workflows/test-eql.yml
+++ b/.github/workflows/test-eql.yml
@@ -154,7 +154,7 @@ jobs:
       # its `on:`-level `paths:` has already decided whether the run happens.
       - id: f
         if: github.event_name == 'pull_request'
-        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+        uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3
         with:
           # Every path except the workflow itself gained the `packages/eql/`
           # prefix with the subtree. dorny/paths-filter matches against


### PR DESCRIPTION
## Summary

Minor/patch bumps of 3 GitHub Actions: `github/codeql-action` 4.37.5 → 4.37.7, `dorny/paths-filter`, and the OSV scanner action, across `codeql.yml`, `osv-scanner.yml`, and `test-eql.yml`.

This is Dependabot's #933 re-opened from a maintainer branch. Its CI failure (the EQL PG17 SQLx shards) was unrelated to this diff: Dependabot-triggered workflows read the Dependabot secrets store, whose CipherStash credentials belong to a different keyset, so the suite's pinned SteVec selector tests fail on every Dependabot PR. This PR touching only workflow files and failing the identical tests is what proved the failure environmental.

## Changes

- `.github/workflows/codeql.yml`, `.github/workflows/osv-scanner.yml`, `.github/workflows/test-eql.yml`: action version bumps (same commit as #933, cherry-picked)

## Verification

- Cherry-pick applied cleanly onto current main.
- CI on this PR is the verification.

## Related

- Replaces #933 (closed in favour of this PR).

https://claude.ai/code/session_01PS9J6pu3FmmQvJHxwTVJUc